### PR TITLE
新規プロジェクト詳細登録機能及び、登録後の該当プロジェクトに対する詳細一覧表示機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+# 単価入力の際に、カンマ、通過を自動入力するための
+gem 'autonumeric-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    autonumeric-rails (2.0.0.1)
+      jquery-rails (>= 2.0.2)
     autoprefixer-rails (10.0.1.3)
       execjs
     bcrypt (3.1.13)
@@ -293,6 +295,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autonumeric-rails
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   byebug

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,6 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
-
+//= require jquery
+//= require jquery_ujs
+//= require autonumeric

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,5 +9,7 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
+}
+).call(this);
 
-}).call(this);
+

--- a/app/assets/javascripts/sales_conditions.js.coffee
+++ b/app/assets/javascripts/sales_conditions.js.coffee
@@ -2,3 +2,9 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
+# $(function() {
+#   $(document).trigger('refresh_autonumeric')
+#   $(document).ready(ready)
+#   $(document).on('page:load', ready)
+# });
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -252,7 +252,7 @@ footer {
 .notifications {
   color: white;
   text-align: center;  
-
+  }
   .notice {
     background-color: lightBlue;
   }
@@ -260,4 +260,3 @@ footer {
   .alert {
     background-color: rgb(255, 81, 0);
   }
-}

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -1,3 +1,54 @@
 // Place all the styles related to the Projects controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+
+table{
+  width: 60px;
+  border-collapse:separate;
+  border-spacing: 0;
+}
+
+table th:first-child{
+  border-radius: 5px 0 0 0;
+}
+
+table th:last-child{
+  border-radius: 0 5px 0 0;
+  border-right: 1px solid #3c6690;
+}
+
+table th{
+  text-align: left;
+  color:white;
+  background: linear-gradient(#829ebc,#225588);
+  border-left: 1px solid #3c6690;
+  border-top: 1px solid #3c6690;
+  border-bottom: 1px solid #3c6690;
+  box-shadow: 0px 1px 1px rgba(255,255,255,0.3) inset;
+  width: 50%;
+  padding: 10px 0;
+}
+
+table td{
+  text-align: center;
+  border-left: 1px solid #a8b7c5;
+  border-bottom: 1px solid #a8b7c5;
+  border-top:none;
+  box-shadow: 0px -3px 5px 1px #eee inset;
+  width: 25%;
+  padding: 10px 0;
+}
+
+table td:last-child{
+  border-right: 1px solid #a8b7c5;
+}
+
+table tr:last-child td:first-child {
+  border-radius: 0 0 0 5px;
+}
+
+table tr:last-child td:last-child {
+  border-radius: 0 0 5px 0;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
 # Deviseで追加したカラムを利用する機能（ユーザ登録、ログイン認証など）の場合、configure_permitted_parametersの実行が必要
 before_action :configure_permitted_parameters, if: :devise_controller?
+#  before_action :move_to_signed_in, exept: [:/ ]
 # before_action :authenticate_user!
 
 
@@ -33,10 +34,19 @@ protected
 
 # サインアウト後のリダイレクト先をトップページへ
   def after_sign_out_path_for(resource)
-    # flash[:alert] = "ログアウトしました"
+    flash[:alert] = "ログアウトしました"
     root_path
   end
 
+
+  def move_to_signed_in
+    unless user_signed_in?
+      #サインインしていないユーザーはログインページが表示される
+      redirect_to  root_path
+    end
+  end
+
+  
 
 end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,15 +1,15 @@
 class PostsController < ApplicationController
 
+
+
   def index
     @posts = Post.all
     @customers = Customer.all
     @projects = Project.all
-    unless user_signed_in?
-      redirect_to root_path
-    end
+    move_to_signed_in
   end
   
-  
+
   def new
     @customers = Customer.all
   end
@@ -24,5 +24,5 @@ class PostsController < ApplicationController
   def post_params
     params.permit(:content)
   end
-  
+
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,7 +22,9 @@ class ProjectsController < ApplicationController
 
   def show
     @customers = Customer.all
+    @sales_conditions = SalesCondition.where project_id: params[:id]
     @project = Project.find(params[:id])
+    move_to_signed_in
   end
 
   def edit
@@ -34,7 +36,7 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     @project.update(project_params)
       redirect_to controller: 'posts', action: 'index' 
-      flash[:notice] = '顧客名更新しました'
+      flash[:notice] = 'プロジェクト更新しました'
      
   end
 

--- a/app/controllers/sales_conditions_controller.rb
+++ b/app/controllers/sales_conditions_controller.rb
@@ -8,22 +8,22 @@ class SalesConditionsController < ApplicationController
     @customers = Customer.all
     @project = Project.find(params[:project_id])
     @sales_condition = SalesCondition.new
-
+    move_to_signed_in
   end
 
   def create
+    # binding.pry
     @project = Project.find(params[:project_id])
-    @sales_condition = Sales_condition.new(sales_condition_params)
-    @sales_condition.project_id = current_project.id
+    @sales_condition = SalesCondition.new(sales_condition_params)
+    @sales_condition.project_id = params[:project_id]
     @customers = Customer.all
-    pry.binding
-    
+
     if @sales_condition.save
-      redirect_to controller: 'posts', action: 'index' 
+      redirect_to controller: 'posts', action: 'index'
       flash[:notice] = '登録しました'
     else
-      redirect_to controller: 'posts', action: 'index' 
-      flash[:notice] = '保存できませんでした'
+      redirect_to controller: 'sales_conditions', action: 'new'
+      flash[:alert] = '保存できませんでした'
     end
   end
 
@@ -40,22 +40,29 @@ class SalesConditionsController < ApplicationController
   def update
     @project = Project.find(params[:id])
     @project.update(project_params)
-      redirect_to controller: 'posts', action: 'index' 
-      flash[:notice] = '顧客名更新しました'
-     
+      redirect_to controller: 'posts', action: 'index'
+      flash[:notice] = 'プロジェクト詳細更新しました'
+
   end
 
   def destroy
     Project.find(params[:id]).destroy
-      redirect_to controller: 'posts', action: 'index' 
+      redirect_to controller: 'posts', action: 'index'
       flash[:notice] = '顧客削除しました'
   end
 
 
 
-  private
+private
   def sales_condition_params
-    params.require(:sales_condition_params).permit(:part_number, :Prot, :mp_date, :project_id, :sell_price, :buy_price, :quantity_month, :mp_site, :vendor)
+    params.require(:sales_condition).permit(:vendor, :part_number, :prot_date, :mp_date, :sell_price, :buy_price, :quantity_month, :mp_site )
+    # 
+    # ストロングパラメータの設置のため、ネストされているルーティングの場合、今回は
+    # resources :projects do
+    #   resources :posts
+    #   resources :sales_conditions
+    # end
+    # params.permit(:)
   end
 
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
     validates :content, presence: true
     belongs_to :user
+    belongs_to :sales_condition
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
    
-  validates :project_name, presence: true, uniqueness: true
-  has_many :sales_conditions
+  validates :project_name, presence: true
+  has_many :sales_condition
 
 end

--- a/app/models/sales_condition.rb
+++ b/app/models/sales_condition.rb
@@ -1,3 +1,12 @@
 class SalesCondition < ApplicationRecord
   belongs_to :project 
+  validate :mp_date_cannot_be_in_prot_date
+
+  def mp_date_cannot_be_in_prot_date
+    if mp_date.present? && mp_date < prot_date
+      errors.add(:mp_date, ": 試作日より過去の日付は使用できません")
+      # flash[:notice] = '試作日より過去の日付は使用できません'
+    end
+  end
+
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,3 +1,3 @@
-<%= render 'shared/flash_messages' %>
+<%# <%= render 'shared/flash_messages' %> 
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,15 +17,11 @@
   <header></header>
   
   <body class = body>
-    
-    <div class="notifications">
-      <%flash.each do |key,value|%>
-        <%=content_tag(:div, value, class:key) %>
-      <%end%>
-    </div>
-
-
-    <%# <%= render 'shared/header' %> 
+    <div class= notifications>
+      <%= flash.each do |key,value| %>
+        <%= content_tag(:div, value, class:key) %> 
+      <% end %>
+    </div > 
     <%= yield %>
   </body>
 

--- a/app/views/posts/_main_index.html.erb
+++ b/app/views/posts/_main_index.html.erb
@@ -183,6 +183,7 @@
       "更新日" <%=  l hoge.updated_at %> <br>
     <% end %>
   </p>
+
   </div>
 
   <div>

--- a/app/views/posts/_main_view.html.erb
+++ b/app/views/posts/_main_view.html.erb
@@ -47,7 +47,9 @@
       <button type="button" class="btn_new" onclick="location.href='/projects/new'"><i class="fas fa-edit"></i>新規Project作成</button>
 
     </div>
-    </body>
+
+
+</body>
     
     
 

--- a/app/views/posts/_side_bar.html.erb
+++ b/app/views/posts/_side_bar.html.erb
@@ -16,7 +16,7 @@
     </div>
       <div class=customer_list>
         <div class = list_box>
-          <b><font size="6"><p class = customer_name>顧客名</font></b><br>チェックボックス：ソート</p>
+          <b><font size="5"><p class = customer_name>顧客名</font></b><br>チェックボックス：ソート</p>
             <% @customers.each do |hoge| %>
               <p>
               <%= check_box_tag :sample %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,6 +7,7 @@
   <%= render partial:'side_bar' %>
   <%= render partial:'main_view' %>
   <%= render partial:'main_index' %>
+
   </div>
     <footer>
     <small>&copy; 2020 Sales Note </small>

--- a/app/views/projects/_show_project.html.erb
+++ b/app/views/projects/_show_project.html.erb
@@ -1,7 +1,7 @@
 <body>
   <div class= project_list>
 
-  <h1>Projects詳細</h1>
+  <h1>Projects詳 細</h1>
 
   <%= form_with(model: @project, local: true) do |form| %>
     <%= form.label :顧客名 %><br>
@@ -20,5 +20,33 @@
   <button type="button" class="btn_new" onclick="location.href='/index'"><i class="fas fa-undo-alt"></i>戻る</button>
 
 
-    </div>
+  <div class= sales_condition_index>
+    <table border = "1", bordercolor="black">
+        <tr>
+          <th>ソート</th>
+          <th>メーカー</th>
+          <th>型番</th>
+          <th>試作時期</th>
+          <th>量産時期</th>
+          <th>販売単価</th>
+          <th>仕入れ単価</th>
+          <th>月産数量</th>
+          <th>量産場所</th>
+          <th colspan="3"></th>
+        </tr>
+        <% @sales_conditions.each do |good| %>
+          <tr>
+            <td><%= check_box_tag :sample %></td>
+            <td><%= good.vendor %></td>
+            <td><%= good.part_number %></td>
+            <td><%= good.prot_date %></td>
+            <td><%= good.mp_date %></td>
+            <td><%= good.sell_price %></td>
+            <td><%= good.buy_price %></td>
+            <td><%= good.quantity_month %></td>
+            <td><%= good.mp_site %></td>
+          </tr>
+        <% end %>
+    </table>
+  </div>
 </body> 

--- a/app/views/sales_conditions/_new_sales_condition_registor.html.erb
+++ b/app/views/sales_conditions/_new_sales_condition_registor.html.erb
@@ -3,9 +3,25 @@
 
   <h1>新規詳細登録</h1>
 
-  <%= form_with model: [@project, @sales_condition] do |form| %>
-     <%= form.label :メーカー名 %><br> 
-     <%= form.text_field :vendor %> 
+  <%= form_with(model:[@project, @sales_condition]) do |form| %>
+     <%= form.label :vendor, "メーカー名" %><br> 
+     <%= form.text_field :vendor %> <br>
+     <%= form.label :part_number, "型番" %><br> 
+     <%= form.text_field :part_number %>  <br> 
+     <%= form.label :mp_date, "量産時期" %> <br> 
+     <%= form.date_select :mp_date %> <br> 
+     <%= form.label :prot_date, "試作時期" %> <br> 
+     <%= form.date_select :prot_date %> <br> 
+     <%= form.label :sell_price, "仕入単価" %> <br> 
+     <%= form.text_field :sell_price, data: { autonumeric: { aSign: '$ ', mDec: 0 } }%> <br> 
+     <%= form.label :buy_price, "販売単価" %> <br> 
+     <%= form.text_field :buy_price, data: { autonumeric: { aSign: '$ ', mDec: 0 } }%> <br> 
+     <%= form.label :quantity_month, "月産数量" %> <br> 
+     <%= form.text_field :quantity_month %> <br> 
+     <%= form.label :mp_site, "量産場所" %> <br> 
+     <%= form.text_field :mp_site %> <br>
+     
+
      <%= form.submit "保存", class: "btn_delete" %> 
   <% end %>  
 

--- a/app/views/sales_conditions/new.html.erb
+++ b/app/views/sales_conditions/new.html.erb
@@ -7,6 +7,8 @@
   
 
 
+
+
   </div>
   <footer>
     <small>&copy; 2020 Sales Note </small>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,31 +3,22 @@ Rails.application.routes.draw do
   devise_for :users
 
   devise_scope :user do
-    post '/homes/guest_sign_in', to: 'homes#new_guest'  
+    post 'homes/guest_sign_in', to: 'homes#new_guest' 
   end
   
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   
   resources :customers
-  resources :projects
-  
-  
+  resources :posts
   resources :projects do
-    resources :posts
     resources :sales_conditions
   end
-  
+
   # アプリケーションを立ち上げると、同時に/openingsのページにアクセスされる
   root to: redirect('openings')
   get 'openings', to: 'openings#index'
   get 'index', to: 'posts#index'
   get 'users/edit', to: 'users#edit'
-
-  post 'homes/guest_sign_in', to: 'posts#index'
-
-  devise_scope :user do
-    post 'homes/guest_sign_in', to: 'posts#index'
-  end
-
-
+  # post 'homes/guest_sign_in', to: 'posts#index'
+  
 end

--- a/db/migrate/20210223232907_change_data_sell_price_to_sales_conditions.rb
+++ b/db/migrate/20210223232907_change_data_sell_price_to_sales_conditions.rb
@@ -1,0 +1,5 @@
+class ChangeDataSellPriceToSalesConditions < ActiveRecord::Migration[5.2]
+  def change
+    change_column :sales_conditions, :quantity_month, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_074017) do
+ActiveRecord::Schema.define(version: 2021_02_23_232907) do
 
   create_table "customers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "customer_name"
@@ -39,9 +39,9 @@ ActiveRecord::Schema.define(version: 2021_02_20_074017) do
     t.string "part_number"
     t.date "prot_date"
     t.date "mp_date"
-    t.decimal "sell_price", precision: 10
-    t.decimal "buy_price", precision: 10
-    t.integer "quantity_month"
+    t.decimal "sell_price", precision: 12, scale: 4
+    t.decimal "buy_price", precision: 12, scale: 4
+    t.decimal "quantity_month", precision: 10
     t.string "mp_site"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
実装理由：
プロジェクトに対する詳細登録及び、それぞれの売上、利益を算出するためのパラメータ入力が必要であるため
詳細一覧機能に対し、プロジェクト毎に抽出できるようにするため
